### PR TITLE
Fix readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ This will trigger a 5.8Gb download
 
 The [entrypoint](./docker/entrypoint-aws.bash) for the `corticometrics/fs6-aws` container will perform some pre- and post-processing steps, depending on certain environment variables.
 
-### The `FS_KEY` environemnt variable
+### The `FS_KEY` environment variable
 
 If `FS_KEY` is set.  The string is decoded from base64, and written to the file `$FREESURFER_HOME/license.txt`.  This occurs before the commands passed to the container are executed.
 
@@ -31,17 +31,17 @@ Once you have your license, use the output of the following command to set the `
 cat $FREESURFER_HOME/license.txt | base64 -w 0
 ```
 
-### The `FS_SUB_NAME` environemnt variable
+### The `FS_SUB_NAME` environment variable
 
 This environment varibale is only used in conjunction with `FS_SUB_S3_IN` and `FS_SUB_S3_OUT` (see below)
 
-### The `FS_SUB_S3_IN` environemnt variable
+### The `FS_SUB_S3_IN` environment variable
 
 If this variable *and* `FS_SUB_NAME` are set.  The container will attempt to recursivly copy the contents of `${FS_SUB_S3_IN}/${FS_SUB_NAME}` to `${SUBJECTS_DIR}/${FS_SUB_NAME}` (`SUBJECTS_DIR` is set to `/subjects` by the docker container).  This occurs before the commands passed to the container are executed.  
 
 If either `FS_SUB_S3_IN` *or* `FS_SUB_NAME` is not defined, this action wont be performed.  So, alternatively, you could mount a docker-volume or an external directory to `/subjects` to get your subject data into the container.
 
-### The `FS_SUB_S3_OUT` environemnt variable
+### The `FS_SUB_S3_OUT` environment variable
 
 If this variable *and* `FS_SUB_NAME` are set.  The container will attempt to recursivly copy the contents of `${SUBJECTS_DIR}/${FS_SUB_NAME}` to `${FS_SUB_S3_OUT}/${FS_SUB_NAME}` (`SUBJECTS_DIR` is set to `/subjects` by the docker container).  This occurs after the commands passed to the container are executed.  
 
@@ -58,7 +58,9 @@ When running though AWS batch.  You either use these environment variables, or c
 ### Launch the container locally, drop into a bash shell.
 
 ```
-docker run -it corticometrics/fs6-aws:latest /bin/bash
+docker run -it --rm \
+corticometrics/fs6-aws:latest \
+/bin/bash
 ```
 
 This doesn't have a FreeSurfer license or any subject data, so it's not particularily interesting.  You can confirm that FreeSurfer wont work by trying something like:
@@ -70,7 +72,10 @@ mri_convert /opt/freesurfer/subjects/sample-001.mgz ~/test.nii.gz
 ### Launch the container locally with a license, drop into a bash shell.
 
 ```
-docker run -it -e FS_KEY='xxx' corticometrics/fs6-aws:latest /bin/bash
+docker run -it --rm \
+-e FS_KEY='xxx' \
+corticometrics/fs6-aws:latest \
+/bin/bash
 ```
 
 Replace `xxx` with the output of `cat $FREESURFER_HOME/license.txt|base64`.  You can get a `license.txt` file for free [here](https://surfer.nmr.mgh.harvard.edu/registration.html)
@@ -84,7 +89,11 @@ mri_convert /opt/freesurfer/subjects/sample-001.mgz ~/test.nii.gz
 ### Launch the container locally with a FreeSurfer license and mount the subject data from a local drive; drop into a bash shell.
 
 ```
-docker run -it -e FS_KEY='xxx' -v /path/to/my/subject_data:/subjects corticometrics/fs6-aws:latest /bin/bash
+docker run -it --rm \
+-e FS_KEY='xxx' \
+-v /path/to/my/subject_data:/subjects \
+corticometrics/fs6-aws:latest \
+/bin/bash
 ```
 
 `/path/to/my/subject_data` is where your subject data is kept on your local machine.  Subject data should always be mapped to `/subjects` inside the container
@@ -97,7 +106,11 @@ ls -lR /subjects
 ### Launch the container locally with a FreeSurfer license and mount the subject data from a local drive; run a recon-all of the subject bert.
   
 ```
-docker run -it -e FS_KEY='xxx' -v /path/to/my/subject_data:/subjects corticometrics/fs6-aws:latest recon-all -s bert -all -parallel
+docker run -it --rm \
+-e FS_KEY='xxx' \
+-v /path/to/my/subject_data:/subjects \
+corticometrics/fs6-aws:latest \
+recon-all -s bert -all -parallel
 ```
 
 This assumes the subject bert lives in a standard FreeSurfer subject directory structure under `/path/to/my/subject_data`. It will take a while to run, so if you want to kill it, from another terminal (outside the container) run `docker ps` to find the containerID, then run `docker kill <containerID>`
@@ -105,7 +118,11 @@ This assumes the subject bert lives in a standard FreeSurfer subject directory s
 ### Launch the container locally with a FreeSurfer license and AWS permissions; Drop into a bash shell.
 
 ```
-docker run -it -e FS_KEY='xxx' -e AWS_ACCESS_KEY_ID='xxx' -e AWS_SECRET_ACCESS_KEY='xxx' corticometrics/fs6-aws /bin/bash
+docker run -it --rm \
+-e FS_KEY='xxx' \
+-e AWS_ACCESS_KEY_ID='xxx' \
+-e AWS_SECRET_ACCESS_KEY='xxx' \
+corticometrics/fs6-aws /bin/bash
 ```
 
 See [Creating an IAM User in Your AWS Account](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) to get values for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.  If you just want to do a quick test, create a user and give it `AmazonS3FullAccess` but note this is not best practice.  See AWS docs for more info.  You can test it by trying to run
@@ -126,7 +143,15 @@ See [Working with Amazon S3 Buckets](http://docs.aws.amazon.com/AmazonS3/latest/
 ### Launch the container locally with a FreeSurfer license and AWS permissions. Copy over a subject from S3, run recon-all, Copy results back to S3
 
 ```
-docker run -it -e FS_KEY='xxx' -e AWS_ACCESS_KEY_ID='xxx' -e AWS_SECRET_ACCESS_KEY='xxx' -e FS_SUB_S3_IN='s3://my-bucket/subjects/' -e FS_SUB_S3_OUT='s3://my-bucket/subjects-fs6-recon/' -e FS_SUB_NAME='bert' corticometrics/fs6-aws recon-all -s bert -all -parallel
+docker run -it --rm \
+-e FS_KEY='xxx' \
+-e AWS_ACCESS_KEY_ID='xxx' \
+-e AWS_SECRET_ACCESS_KEY='xxx' \
+-e FS_SUB_S3_IN='s3://my-bucket/subjects/' \
+-e FS_SUB_S3_OUT='s3://my-bucket/subjects-fs6-recon/' \
+-e FS_SUB_NAME='bert' \
+corticometrics/fs6-aws \
+recon-all -s bert -all -parallel
 ```
 
 This will take a while, so you can kill it from another terminal (outside the container) with `docker ps` to find the containerID, then run `docker kill <containerID>`.
@@ -137,6 +162,6 @@ If this step works, then you're ready to submit jobs to AWS batch!
   - AWS fetch and run script ([article](https://aws.amazon.com/blogs/compute/creating-a-simple-fetch-and-run-aws-batch-job/) | [github](https://github.com/awslabs/aws-batch-helpers/tree/master/fetch-and-run) )
   - [BIDS fs6 container](https://github.com/BIDS-Apps/freesurfer/blob/master/Dockerfile)
   - [AWS batch manual](http://docs.aws.amazon.com/batch/latest/userguide/batch_user.pdf)
-
+  - [Learn Docker](https://docs.docker.com/learn/)
 
 

--- a/readme.md
+++ b/readme.md
@@ -59,8 +59,8 @@ When running though AWS batch.  You either use these environment variables, or c
 
 ```
 docker run -it --rm \
-corticometrics/fs6-aws:latest \
-/bin/bash
+  corticometrics/fs6-aws:latest \
+  /bin/bash
 ```
 
 This doesn't have a FreeSurfer license or any subject data, so it's not particularily interesting.  You can confirm that FreeSurfer wont work by trying something like:
@@ -73,9 +73,9 @@ mri_convert /opt/freesurfer/subjects/sample-001.mgz ~/test.nii.gz
 
 ```
 docker run -it --rm \
--e FS_KEY='xxx' \
-corticometrics/fs6-aws:latest \
-/bin/bash
+  -e FS_KEY='xxx' \
+  corticometrics/fs6-aws:latest \
+  /bin/bash
 ```
 
 Replace `xxx` with the output of `cat $FREESURFER_HOME/license.txt|base64`.  You can get a `license.txt` file for free [here](https://surfer.nmr.mgh.harvard.edu/registration.html)
@@ -90,10 +90,10 @@ mri_convert /opt/freesurfer/subjects/sample-001.mgz ~/test.nii.gz
 
 ```
 docker run -it --rm \
--e FS_KEY='xxx' \
--v /path/to/my/subject_data:/subjects \
-corticometrics/fs6-aws:latest \
-/bin/bash
+  -e FS_KEY='xxx' \
+  -v /path/to/my/subject_data:/subjects \
+  corticometrics/fs6-aws:latest \
+  /bin/bash
 ```
 
 `/path/to/my/subject_data` is where your subject data is kept on your local machine.  Subject data should always be mapped to `/subjects` inside the container
@@ -107,10 +107,10 @@ ls -lR /subjects
   
 ```
 docker run -it --rm \
--e FS_KEY='xxx' \
--v /path/to/my/subject_data:/subjects \
-corticometrics/fs6-aws:latest \
-recon-all -s bert -all -parallel
+  -e FS_KEY='xxx' \
+  -v /path/to/my/subject_data:/subjects \
+  corticometrics/fs6-aws:latest \
+  recon-all -s bert -all -parallel
 ```
 
 This assumes the subject bert lives in a standard FreeSurfer subject directory structure under `/path/to/my/subject_data`. It will take a while to run, so if you want to kill it, from another terminal (outside the container) run `docker ps` to find the containerID, then run `docker kill <containerID>`
@@ -119,10 +119,10 @@ This assumes the subject bert lives in a standard FreeSurfer subject directory s
 
 ```
 docker run -it --rm \
--e FS_KEY='xxx' \
--e AWS_ACCESS_KEY_ID='xxx' \
--e AWS_SECRET_ACCESS_KEY='xxx' \
-corticometrics/fs6-aws /bin/bash
+  -e FS_KEY='xxx' \
+  -e AWS_ACCESS_KEY_ID='xxx' \
+  -e AWS_SECRET_ACCESS_KEY='xxx' \
+  corticometrics/fs6-aws /bin/bash
 ```
 
 See [Creating an IAM User in Your AWS Account](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) to get values for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.  If you just want to do a quick test, create a user and give it `AmazonS3FullAccess` but note this is not best practice.  See AWS docs for more info.  You can test it by trying to run
@@ -144,14 +144,14 @@ See [Working with Amazon S3 Buckets](http://docs.aws.amazon.com/AmazonS3/latest/
 
 ```
 docker run -it --rm \
--e FS_KEY='xxx' \
--e AWS_ACCESS_KEY_ID='xxx' \
--e AWS_SECRET_ACCESS_KEY='xxx' \
--e FS_SUB_S3_IN='s3://my-bucket/subjects/' \
--e FS_SUB_S3_OUT='s3://my-bucket/subjects-fs6-recon/' \
--e FS_SUB_NAME='bert' \
-corticometrics/fs6-aws \
-recon-all -s bert -all -parallel
+  -e FS_KEY='xxx' \
+  -e AWS_ACCESS_KEY_ID='xxx' \
+  -e AWS_SECRET_ACCESS_KEY='xxx' \
+  -e FS_SUB_S3_IN='s3://my-bucket/subjects/' \
+  -e FS_SUB_S3_OUT='s3://my-bucket/subjects-fs6-recon/' \
+  -e FS_SUB_NAME='bert' \
+  corticometrics/fs6-aws \
+  recon-all -s bert -all -parallel
 ```
 
 This will take a while, so you can kill it from another terminal (outside the container) with `docker ps` to find the containerID, then run `docker kill <containerID>`.

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Most of FreeSurfer will not work if this key is not set.  Liceneses are distribu
 
 Once you have your license, use the output of the following command to set the `FS_KEY` variable:
 ```
-cat $FREESURFER_HOME/license.txt | base64
+cat $FREESURFER_HOME/license.txt | base64 -w 0
 ```
 
 ### The `FS_SUB_NAME` environemnt variable


### PR DESCRIPTION
I fixed some typos and the base64 command (for some reason i needed the -w 0, or else it adds a new line after 76 characters). I may have been overzealous in splitting commands into new lines, but they were hard to read if they're only one line. Also,  running docker with the --rm command cleans up the container after it's done, which is probably what is wanted. [Here's the reference.](https://docs.docker.com/engine/reference/run/#clean-up---rm)