### PR TITLE
Update to create FS 7.1.1 container

### DIFF
--- a/docker/dockerfile--fs7-aws
+++ b/docker/dockerfile--fs7-aws
@@ -1,0 +1,7 @@
+FROM corticometrics/fs7-base:latest
+
+RUN yum -y install aws-cli
+
+ADD docker/entrypoint-aws.bash /usr/local/bin/entrypoint-aws.bash
+ENTRYPOINT ["/usr/local/bin/entrypoint-aws.bash"]
+

--- a/docker/dockerfile--fs7-base
+++ b/docker/dockerfile--fs7-base
@@ -1,0 +1,25 @@
+FROM corticometrics/fs7-payload:latest
+
+RUN yum -y install binutils libGLU libXmu
+
+# Configure environment
+ENV FS_OVERRIDE 0
+ENV OS Linux
+ENV FIX_VERTEX_AREA=
+ENV FSF_OUTPUT_FORMAT nii.gz
+ENV SUBJECTS_DIR /subjects
+VOLUME /subjects
+# ---------------------------------------------------------------------------
+ENV MNI_DIR $FREESURFER_HOME/mni
+ENV LOCAL_DIR $FREESURFER_HOME/local
+ENV FSFAST_HOME $FREESURFER_HOME/fsfast
+ENV MINC_BIN_DIR $FREESURFER_HOME/mni/bin
+ENV MINC_LIB_DIR $FREESURFER_HOME/mni/lib
+ENV MNI_DATAPATH $FREESURFER_HOME/mni/data
+ENV FMRI_ANALYSIS_DIR $FREESURFER_HOME/fsfast
+ENV PERL5LIB $FREESURFER_HOME/mni/lib/perl5/5.8.5
+ENV MNI_PERL5LIB $FREESURFER_HOME/mni/lib/perl5/5.8.5
+ENV PATH $FREESURFER_HOME/bin:$FREESURFER_HOME/fsfast/bin:$FREESURFER_HOME/tktools:$FREESURFER_HOME/mni/bin:$PATH
+
+ADD docker/entrypoint-base.bash /usr/local/bin/entrypoint-base.bash
+ENTRYPOINT ["/usr/local/bin/entrypoint-base.bash"]

--- a/docker/dockerfile--fs7-payload
+++ b/docker/dockerfile--fs7-payload
@@ -1,0 +1,21 @@
+FROM amazonlinux:latest
+
+RUN yum -y update
+RUN yum -y install sudo nano find which unzip wget curl tar tcsh bc libgomp net-tools psmisc perl 
+
+RUN wget -qO- https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.1.1/freesurfer-linux-centos7_x86_64-7.1.1.tar.gz | tar zxv -C / \
+     --exclude='freesurfer/trctrain' \
+     --exclude='freesurfer/subjects/fsaverage_sym' \
+     --exclude='freesurfer/subjects/fsaverage3' \
+     --exclude='freesurfer/subjects/fsaverage4' \
+     --exclude='freesurfer/subjects/fsaverage5' \
+     --exclude='freesurfer/subjects/fsaverage6' \
+     --exclude='freesurfer/subjects/cvs_avg35' \
+     --exclude='freesurfer/subjects/cvs_avg35_inMNI152' \
+     --exclude='freesurfer/subjects/bert' \
+     --exclude='freesurfer/subjects/V1_average' \
+     --exclude='freesurfer/average/mult-comp-cor' \
+     --exclude='freesurfer/lib/cuda' \
+     --exclude='freesurfer/lib/qt'
+
+ENV FREESURFER_HOME /freesurfer

--- a/makefile
+++ b/makefile
@@ -10,3 +10,19 @@ fs6-aws: fs6-base docker/dockerfile--fs6-aws
 	docker build --no-cache -f ./docker/dockerfile--fs6-aws  -t corticometrics/fs6-aws .
 
 
+fs7: fs7-payload fs7-base fs7-aws
+
+fs7-payload: docker/dockerfile--fs7-payload
+	docker build --no-cache -f ./docker/dockerfile--fs7-payload -t corticometrics/fs7-payload .
+
+fs7-base: docker/dockerfile--fs7-base
+	docker build --no-cache -f ./docker/dockerfile--fs7-base -t corticometrics/fs7-base .
+
+fs7-aws: fs6-base docker/dockerfile--fs7-aws
+	docker build --no-cache -f ./docker/dockerfile--fs7-aws  -t corticometrics/fs7-aws .
+
+PUSH_VERSION ?= fs7
+push:
+	docker push corticometrics/${PUSH_VERSION}-payload
+	docker push corticometrics/${PUSH_VERSION}-base
+	docker push corticometrics/corticometrics/${PUSH_VERSION}-aws

--- a/makefile
+++ b/makefile
@@ -18,7 +18,7 @@ fs7-payload: docker/dockerfile--fs7-payload
 fs7-base: docker/dockerfile--fs7-base
 	docker build --no-cache -f ./docker/dockerfile--fs7-base -t corticometrics/fs7-base .
 
-fs7-aws: fs6-base docker/dockerfile--fs7-aws
+fs7-aws: fs7-base docker/dockerfile--fs7-aws
 	docker build --no-cache -f ./docker/dockerfile--fs7-aws  -t corticometrics/fs7-aws .
 
 PUSH_VERSION ?= fs7

--- a/makefile
+++ b/makefile
@@ -25,4 +25,4 @@ PUSH_VERSION ?= fs7
 push:
 	docker push corticometrics/${PUSH_VERSION}-payload
 	docker push corticometrics/${PUSH_VERSION}-base
-	docker push corticometrics/corticometrics/${PUSH_VERSION}-aws
+	docker push corticometrics/${PUSH_VERSION}-aws

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,9 @@
 
 This guide describes how to run [FreeSurfer 6.0](https://surfer.nmr.mgh.harvard.edu/fswiki/ReleaseNotes) inside a [docker](https://www.docker.com/) container on [AWS batch](https://aws.amazon.com/batch/).
 
+**NOTE**: A FreeSurfer 7.1.1 container is now available! The commands below should work by changing `corticometrics/fs6-aws` to `corticometrics/fs7-aws` when running the commands below.
+The new container hasn't been tested as thoroughly, so please leave an issue if you notice anything strange!
+
 ## Setup
 
 - See [Setting up with AWS batch](http://docs.aws.amazon.com/batch/latest/userguide/get-set-up-for-aws-batch.html)


### PR DESCRIPTION
This basically copies all the `fs6` Dockerfiles to `fs7` versions. The only real change is the package that is downloaded from LCN (v7.1.1 instead of v6), though potentially new changes can be introduced later.

Also adds a push command to the makefile